### PR TITLE
Update zoxide.nuspec version bump

### DIFF
--- a/zoxide/zoxide.nuspec
+++ b/zoxide/zoxide.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>zoxide</id>
-    <version>0.9.2</version>
+    <version>0.9.8</version>
     <packageSourceUrl>https://github.com/sitiom/chocolatey-packages/tree/main/zoxide</packageSourceUrl>
     <owners>sitiom</owners>
     <!-- ============================== -->


### PR DESCRIPTION
Not sure what else needs to change. Other files referencing version seem to indicate automatic evaluation at runtime. The version showing up in Chocolatey is 0.9.2. The latest is 0.9.8. The latest is needed if you want to use in recent versions of Nushell. Being outdated also has caused at least one bug report to the author of zoxide.